### PR TITLE
Updated configs to match other repo changes

### DIFF
--- a/packer-aem/aws-amazon-linux2-aem62/aem62.yaml
+++ b/packer-aem/aws-amazon-linux2-aem62/aem62.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem62_sp1_cfp18
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/aws-amazon-linux2-aem63/aem63.yaml
+++ b/packer-aem/aws-amazon-linux2-aem63/aem63.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem63_sp2_cfp2
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/aws-amazon-linux2-aem64/aem64.yaml
+++ b/packer-aem/aws-amazon-linux2-aem64/aem64.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem64_sp3
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/aws-centos7-aem62/aem62.yaml
+++ b/packer-aem/aws-centos7-aem62/aem62.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem62_sp1_cfp18
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/aws-centos7-aem63/aem63.yaml
+++ b/packer-aem/aws-centos7-aem63/aem63.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem63_sp2_cfp2
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/aws-centos7-aem64/aem64.yaml
+++ b/packer-aem/aws-centos7-aem64/aem64.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem64_sp3
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/aws-rhel7-aem62/aem62.yaml
+++ b/packer-aem/aws-rhel7-aem62/aem62.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem62_sp1_cfp18
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/aws-rhel7-aem63/aem63.yaml
+++ b/packer-aem/aws-rhel7-aem63/aem63.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem63_sp2_cfp2
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/aws-rhel7-aem64/aem64.yaml
+++ b/packer-aem/aws-rhel7-aem64/aem64.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem64_sp3
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/docker-amazon-linux2-aem62/aem62.yaml
+++ b/packer-aem/docker-amazon-linux2-aem62/aem62.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem62_sp1_cfp18
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/docker-amazon-linux2-aem63/aem63.yaml
+++ b/packer-aem/docker-amazon-linux2-aem63/aem63.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem63_sp2_cfp2
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/docker-amazon-linux2-aem64/aem64.yaml
+++ b/packer-aem/docker-amazon-linux2-aem64/aem64.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem64_sp3
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/docker-centos7-aem62/aem62.yaml
+++ b/packer-aem/docker-centos7-aem62/aem62.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem62_sp1_cfp18
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/docker-centos7-aem63/aem63.yaml
+++ b/packer-aem/docker-centos7-aem63/aem63.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem63_sp2_cfp2
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/docker-centos7-aem64/aem64.yaml
+++ b/packer-aem/docker-centos7-aem64/aem64.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem64_sp3
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/src/aem62.yaml
+++ b/packer-aem/src/aem62.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem62_sp1_cfp18
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/src/aem63.yaml
+++ b/packer-aem/src/aem63.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem63_sp2_cfp2
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license

--- a/packer-aem/src/aem64.yaml
+++ b/packer-aem/src/aem64.yaml
@@ -3,4 +3,4 @@ aem:
   profile: aem64_sp3
 
 aws:
-  aem_license: /aem-opencloud/aoc-sandpit-a/aem-license
+  aem_license: aoc-sandpit-a/aem-license


### PR DESCRIPTION
This MR updates the hello world configs to match the recent change here: https://github.com/shinesolutions/packer-aem/pull/148

In short; AEM now looks up the SSM parameter store value by a subkey to avoid caching data the customer may not want cached (like access keys!) that is not related to AEM. For example:

The SSM Module starts it's lookup at /aem-opencloud/.

The config for AEM packer then appends its config value onto this, for example: aoc-sandpit-a/aem-license

This becomes: /aem-opencloud/aoc-sandpit-a/aem-license.

This ensures all AEM Opencloud key/values are separated from other unrelated values.