### PR TITLE
Refactor variables on packer-aem #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+- Add aws.snapshot_users for volume permission used in snapshot sharing
+
 ### Changed
 - Update Jumphost access security group (from jumphost inbound to instances) with the resource `shn-awsres-03`
 
 ### Removed
 - Removed `inbound_from_bastion_host_security_group` configuration since it's no longer needed in aem-aws-stack-builder 4.34.0
+- Removed dock.source which is deprecated
+- Removed aem.[author|publish].start_opts which are deprecated

--- a/packer-aem/aws-amazon-linux2-aem62/os-amazon-linux2.yaml
+++ b/packer-aem/aws-amazon-linux2-aem62/os-amazon-linux2.yaml
@@ -5,6 +5,3 @@ aws:
   user: ec2-user
   # Amazon Linux 2 AMI 2.0.20181008 x86_64 HVM gp2
   source_ami: ami-02d039674ab9ba947
-
-docker:
-  source: 'amazonlinux:2'

--- a/packer-aem/aws-amazon-linux2-aem62/platform-aws.yaml
+++ b/packer-aem/aws-amazon-linux2-aem62/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-amazon-linux2-aem62/sandpit.yaml
+++ b/packer-aem/aws-amazon-linux2-aem62/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-amazon-linux2-aem63/os-amazon-linux2.yaml
+++ b/packer-aem/aws-amazon-linux2-aem63/os-amazon-linux2.yaml
@@ -5,6 +5,3 @@ aws:
   user: ec2-user
   # Amazon Linux 2 AMI 2.0.20181008 x86_64 HVM gp2
   source_ami: ami-02d039674ab9ba947
-
-docker:
-  source: 'amazonlinux:2'

--- a/packer-aem/aws-amazon-linux2-aem63/platform-aws.yaml
+++ b/packer-aem/aws-amazon-linux2-aem63/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-amazon-linux2-aem63/sandpit.yaml
+++ b/packer-aem/aws-amazon-linux2-aem63/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-amazon-linux2-aem64/os-amazon-linux2.yaml
+++ b/packer-aem/aws-amazon-linux2-aem64/os-amazon-linux2.yaml
@@ -5,6 +5,3 @@ aws:
   user: ec2-user
   # Amazon Linux 2 AMI 2.0.20181008 x86_64 HVM gp2
   source_ami: ami-02d039674ab9ba947
-
-docker:
-  source: 'amazonlinux:2'

--- a/packer-aem/aws-amazon-linux2-aem64/platform-aws.yaml
+++ b/packer-aem/aws-amazon-linux2-aem64/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-amazon-linux2-aem64/sandpit.yaml
+++ b/packer-aem/aws-amazon-linux2-aem64/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-amazon-linux2-aem65/os-amazon-linux2.yaml
+++ b/packer-aem/aws-amazon-linux2-aem65/os-amazon-linux2.yaml
@@ -5,6 +5,3 @@ aws:
   user: ec2-user
   # Amazon Linux 2 AMI 2.0.20181008 x86_64 HVM gp2
   source_ami: ami-02d039674ab9ba947
-
-docker:
-  source: 'amazonlinux:2'

--- a/packer-aem/aws-amazon-linux2-aem65/platform-aws.yaml
+++ b/packer-aem/aws-amazon-linux2-aem65/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-amazon-linux2-aem65/sandpit.yaml
+++ b/packer-aem/aws-amazon-linux2-aem65/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-centos7-aem62/os-centos7.yaml
+++ b/packer-aem/aws-centos7-aem62/os-centos7.yaml
@@ -5,6 +5,3 @@ aws:
   user: centos
   # CentOS Linux 7 x86_64 HVM EBS 1801_01
   source_ami: ami-b6bb47d4
-
-docker:
-  source: 'centos:centos7'

--- a/packer-aem/aws-centos7-aem62/platform-aws.yaml
+++ b/packer-aem/aws-centos7-aem62/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-centos7-aem62/sandpit.yaml
+++ b/packer-aem/aws-centos7-aem62/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-centos7-aem63/os-centos7.yaml
+++ b/packer-aem/aws-centos7-aem63/os-centos7.yaml
@@ -5,6 +5,3 @@ aws:
   user: centos
   # CentOS Linux 7 x86_64 HVM EBS 1801_01
   source_ami: ami-b6bb47d4
-
-docker:
-  source: 'centos:centos7'

--- a/packer-aem/aws-centos7-aem63/platform-aws.yaml
+++ b/packer-aem/aws-centos7-aem63/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-centos7-aem63/sandpit.yaml
+++ b/packer-aem/aws-centos7-aem63/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-centos7-aem64/os-centos7.yaml
+++ b/packer-aem/aws-centos7-aem64/os-centos7.yaml
@@ -5,6 +5,3 @@ aws:
   user: centos
   # CentOS Linux 7 x86_64 HVM EBS 1801_01
   source_ami: ami-b6bb47d4
-
-docker:
-  source: 'centos:centos7'

--- a/packer-aem/aws-centos7-aem64/platform-aws.yaml
+++ b/packer-aem/aws-centos7-aem64/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-centos7-aem64/sandpit.yaml
+++ b/packer-aem/aws-centos7-aem64/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-centos7-aem65/os-centos7.yaml
+++ b/packer-aem/aws-centos7-aem65/os-centos7.yaml
@@ -5,6 +5,3 @@ aws:
   user: centos
   # CentOS Linux 7 x86_64 HVM EBS 1801_01
   source_ami: ami-b6bb47d4
-
-docker:
-  source: 'centos:centos7'

--- a/packer-aem/aws-centos7-aem65/platform-aws.yaml
+++ b/packer-aem/aws-centos7-aem65/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-centos7-aem65/sandpit.yaml
+++ b/packer-aem/aws-centos7-aem65/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-rhel7-aem62/platform-aws.yaml
+++ b/packer-aem/aws-rhel7-aem62/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-rhel7-aem62/sandpit.yaml
+++ b/packer-aem/aws-rhel7-aem62/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-rhel7-aem63/platform-aws.yaml
+++ b/packer-aem/aws-rhel7-aem63/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-rhel7-aem63/sandpit.yaml
+++ b/packer-aem/aws-rhel7-aem63/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-rhel7-aem64/platform-aws.yaml
+++ b/packer-aem/aws-rhel7-aem64/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-rhel7-aem64/sandpit.yaml
+++ b/packer-aem/aws-rhel7-aem64/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-rhel7-aem65/platform-aws.yaml
+++ b/packer-aem/aws-rhel7-aem65/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-rhel7-aem65/sandpit.yaml
+++ b/packer-aem/aws-rhel7-aem65/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-rhel8-aem62/platform-aws.yaml
+++ b/packer-aem/aws-rhel8-aem62/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-rhel8-aem62/sandpit.yaml
+++ b/packer-aem/aws-rhel8-aem62/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-rhel8-aem63/platform-aws.yaml
+++ b/packer-aem/aws-rhel8-aem63/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-rhel8-aem63/sandpit.yaml
+++ b/packer-aem/aws-rhel8-aem63/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-rhel8-aem64/platform-aws.yaml
+++ b/packer-aem/aws-rhel8-aem64/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-rhel8-aem64/sandpit.yaml
+++ b/packer-aem/aws-rhel8-aem64/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/aws-rhel8-aem65/platform-aws.yaml
+++ b/packer-aem/aws-rhel8-aem65/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/aws-rhel8-aem65/sandpit.yaml
+++ b/packer-aem/aws-rhel8-aem65/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/docker-amazon-linux2-aem62/os-amazon-linux2.yaml
+++ b/packer-aem/docker-amazon-linux2-aem62/os-amazon-linux2.yaml
@@ -5,6 +5,3 @@ aws:
   user: ec2-user
   # Amazon Linux 2 AMI 2.0.20181008 x86_64 HVM gp2
   source_ami: ami-02d039674ab9ba947
-
-docker:
-  source: 'amazonlinux:2'

--- a/packer-aem/docker-amazon-linux2-aem62/sandpit.yaml
+++ b/packer-aem/docker-amazon-linux2-aem62/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/docker-amazon-linux2-aem63/os-amazon-linux2.yaml
+++ b/packer-aem/docker-amazon-linux2-aem63/os-amazon-linux2.yaml
@@ -5,6 +5,3 @@ aws:
   user: ec2-user
   # Amazon Linux 2 AMI 2.0.20181008 x86_64 HVM gp2
   source_ami: ami-02d039674ab9ba947
-
-docker:
-  source: 'amazonlinux:2'

--- a/packer-aem/docker-amazon-linux2-aem63/sandpit.yaml
+++ b/packer-aem/docker-amazon-linux2-aem63/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/docker-amazon-linux2-aem64/os-amazon-linux2.yaml
+++ b/packer-aem/docker-amazon-linux2-aem64/os-amazon-linux2.yaml
@@ -5,6 +5,3 @@ aws:
   user: ec2-user
   # Amazon Linux 2 AMI 2.0.20181008 x86_64 HVM gp2
   source_ami: ami-02d039674ab9ba947
-
-docker:
-  source: 'amazonlinux:2'

--- a/packer-aem/docker-amazon-linux2-aem64/sandpit.yaml
+++ b/packer-aem/docker-amazon-linux2-aem64/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/docker-amazon-linux2-aem65/os-amazon-linux2.yaml
+++ b/packer-aem/docker-amazon-linux2-aem65/os-amazon-linux2.yaml
@@ -5,6 +5,3 @@ aws:
   user: ec2-user
   # Amazon Linux 2 AMI 2.0.20181008 x86_64 HVM gp2
   source_ami: ami-02d039674ab9ba947
-
-docker:
-  source: 'amazonlinux:2'

--- a/packer-aem/docker-amazon-linux2-aem65/sandpit.yaml
+++ b/packer-aem/docker-amazon-linux2-aem65/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/docker-centos7-aem62/os-centos7.yaml
+++ b/packer-aem/docker-centos7-aem62/os-centos7.yaml
@@ -5,6 +5,3 @@ aws:
   user: centos
   # CentOS Linux 7 x86_64 HVM EBS 1801_01
   source_ami: ami-b6bb47d4
-
-docker:
-  source: 'centos:centos7'

--- a/packer-aem/docker-centos7-aem62/sandpit.yaml
+++ b/packer-aem/docker-centos7-aem62/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/docker-centos7-aem63/os-centos7.yaml
+++ b/packer-aem/docker-centos7-aem63/os-centos7.yaml
@@ -5,6 +5,3 @@ aws:
   user: centos
   # CentOS Linux 7 x86_64 HVM EBS 1801_01
   source_ami: ami-b6bb47d4
-
-docker:
-  source: 'centos:centos7'

--- a/packer-aem/docker-centos7-aem63/sandpit.yaml
+++ b/packer-aem/docker-centos7-aem63/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/docker-centos7-aem64/os-centos7.yaml
+++ b/packer-aem/docker-centos7-aem64/os-centos7.yaml
@@ -5,6 +5,3 @@ aws:
   user: centos
   # CentOS Linux 7 x86_64 HVM EBS 1801_01
   source_ami: ami-b6bb47d4
-
-docker:
-  source: 'centos:centos7'

--- a/packer-aem/docker-centos7-aem64/sandpit.yaml
+++ b/packer-aem/docker-centos7-aem64/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/docker-centos7-aem65/os-centos7.yaml
+++ b/packer-aem/docker-centos7-aem65/os-centos7.yaml
@@ -5,6 +5,3 @@ aws:
   user: centos
   # CentOS Linux 7 x86_64 HVM EBS 1801_01
   source_ami: ami-b6bb47d4
-
-docker:
-  source: 'centos:centos7'

--- a/packer-aem/docker-centos7-aem65/sandpit.yaml
+++ b/packer-aem/docker-centos7-aem65/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud

--- a/packer-aem/src/os-amazon-linux2.yaml
+++ b/packer-aem/src/os-amazon-linux2.yaml
@@ -5,6 +5,3 @@ aws:
   user: ec2-user
   # Amazon Linux 2 AMI 2.0.20181008 x86_64 HVM gp2
   source_ami: ami-02d039674ab9ba947
-
-docker:
-  source: 'amazonlinux:2'

--- a/packer-aem/src/os-centos7.yaml
+++ b/packer-aem/src/os-centos7.yaml
@@ -5,6 +5,3 @@ aws:
   user: centos
   # CentOS Linux 7 x86_64 HVM EBS 1801_01
   source_ami: ami-b6bb47d4
-
-docker:
-  source: 'centos:centos7'

--- a/packer-aem/src/platform-aws.yaml
+++ b/packer-aem/src/platform-aws.yaml
@@ -12,6 +12,7 @@ aws:
   instance_profile: PackerAemRole
   temporary_security_group_source_cidr: "0.0.0.0/0"
   ami_users: ''
+  snapshot_users: ''
   install_ssm_agent: true
   root_volume_size: 30
   data_volume_size: 75

--- a/packer-aem/src/sandpit.yaml
+++ b/packer-aem/src/sandpit.yaml
@@ -10,10 +10,8 @@ timezone:
 aem:
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
-    start_opts: "-nofork"
   enable_custom_image_provisioner: true
   jdk:
     base_url: s3://aem-opencloud/adobeaemcloud


### PR DESCRIPTION
Refactor variables on packer-aem to pass the variable validation.

- Add aws.snapshot_users for volume permission used in snapshot sharing
- Remove dock.source which is deprecated
- Remove aem.[author|publish].start_opts which are deprecated